### PR TITLE
Use luxon format when setting calendar day numbers

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -252,6 +252,7 @@ export function normalizeMultipleActionValue(val) {
 
 export function normalizeCalendarDay(day) {
   day.datetime = DateTime.fromJSDate(day.date);
+  day.number = +DateTime.fromJSDate(day.date).toFormat('d');
   return day;
 }
 


### PR DESCRIPTION
Fixes https://github.com/cibernox/ember-power-calendar/issues/237.

Uses luxon's `toFormat()` to set the correct calendar number based on the set timezone.