### PR TITLE
Fix check for DateTime instance

### DIFF
--- a/ember-power-calendar-luxon/src/index.js
+++ b/ember-power-calendar-luxon/src/index.js
@@ -175,7 +175,7 @@ export function add(date, quantity, unit) {
 }
 
 export function formatDate(date, format, locale = null) {
-  let datetime = date instanceof DateTime ? date : DateTime.fromJSDate(date);
+  let datetime = DateTime.isDateTime(date) ? date : DateTime.fromJSDate(date);
   if (locale) {
     datetime = datetime.setLocale(locale);
   }


### PR DESCRIPTION
fix #35 

Since luxon `v1.6.0` there exists a function to check if the datetime is luxon, so we should use it